### PR TITLE
Update OpenAI chat model to gpt-5-nano-2025-08-07

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,5 @@
 OPENAI_API_KEY=sk-...
 
 # Optional: Specify a different OpenAI model
-# Default model: gpt-4.1-nano-2025-04-14
-# OPENAI_MODEL=gpt-4.1-nano-2025-04-14
+# Default model: gpt-5-nano-2025-08-07
+# OPENAI_MODEL=gpt-5-nano-2025-08-07

--- a/SYSTEM_PROMPT_README.md
+++ b/SYSTEM_PROMPT_README.md
@@ -223,7 +223,7 @@ const systemPrompt = await buildSystemPrompt()
 
 // Use with OpenAI
 const response = await openai.chat.completions.create({
-  model: "gpt-4",
+  model: "gpt-5-nano-2025-08-07",
   messages: [
     { role: "system", content: systemPrompt },
     { role: "user", content: userMessage }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -19,5 +19,5 @@ export function validateEnv() {
 
 export const env = {
   OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
-  OPENAI_MODEL: process.env.OPENAI_MODEL || 'gpt-4.1-nano-2025-04-14',
+  OPENAI_MODEL: process.env.OPENAI_MODEL || 'gpt-5-nano-2025-08-07',
 }


### PR DESCRIPTION
## Summary
- default to OpenAI model `gpt-5-nano-2025-08-07`
- refresh documentation and env example for new model

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689516cb3fd083208fcf83ab8e9c7177